### PR TITLE
Add Phaser MVP skeleton

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Phaser 3 植物大战僵尸 MVP</title>
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.55.2/dist/phaser.min.js"></script>
+  <script type="module" src="./src/main.js"></script>
+  <style>
+    body {
+      margin: 0;
+      background-color: #0b6623;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
+  </style>
+</head>
+<body>
+</body>
+</html>

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,14 @@
+export default class PvZGame extends Phaser.Scene {
+  constructor() {
+    super({ key: 'PvZGame' });
+  }
+
+  preload() {}
+
+  create() {
+    const { width, height } = this.scale;
+    this.add.rectangle(width / 2, height / 2, width, height, 0x4caf50).setOrigin(0.5);
+  }
+
+  update() {}
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,14 @@
+import PvZGame from './game.js';
+
+const config = {
+  type: Phaser.AUTO,
+  width: 1280,
+  height: 720,
+  backgroundColor: '#2e7d32',
+  parent: document.body,
+  scene: [PvZGame]
+};
+
+window.addEventListener('load', () => {
+  window.pvzGame = new Phaser.Game(config);
+});


### PR DESCRIPTION
## Summary
- add a Phaser-enabled index page that loads the MVP entry point
- configure the main module to bootstrap a 1280x720 game instance
- implement a basic scene that renders a placeholder green background

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68df5bbd2d6483318bb180d94f5527db