### PR TITLE
Add simple card bar and plant placement prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PVZ Web Prototype</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", "PingFang SC", "Microsoft Yahei", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: #e1f3ff;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+
+      header {
+        background: #2675c7;
+        color: white;
+        padding: 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+      }
+
+      #sun-display {
+        font-size: 1.5rem;
+        font-weight: bold;
+      }
+
+      #card-bar {
+        display: flex;
+        gap: 12px;
+      }
+
+      .card {
+        width: 120px;
+        padding: 12px;
+        border-radius: 8px;
+        background: white;
+        color: #1c3a57;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+        border: 2px solid transparent;
+      }
+
+      .card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+      }
+
+      .card.disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+        transform: none;
+        box-shadow: none;
+      }
+
+      .card.selected {
+        border-color: #fdd835;
+        box-shadow: 0 0 0 3px rgba(253, 216, 53, 0.5);
+      }
+
+      .card-title {
+        font-size: 1.1rem;
+        font-weight: bold;
+      }
+
+      .card-body {
+        font-size: 0.9rem;
+        flex: 1;
+      }
+
+      .card-footer {
+        font-size: 0.85rem;
+        color: #0e2e4a;
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: 24px;
+      }
+
+      #board {
+        display: grid;
+        grid-template-columns: repeat(9, 100px);
+        grid-template-rows: repeat(5, 110px);
+        gap: 4px;
+        background: #5ca346;
+        padding: 8px;
+        border-radius: 12px;
+        box-shadow: inset 0 0 0 4px rgba(0, 0, 0, 0.1);
+      }
+
+      .cell {
+        position: relative;
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        transition: transform 0.1s ease, box-shadow 0.1s ease, background 0.1s ease;
+        border: 2px solid rgba(0, 0, 0, 0.05);
+      }
+
+      .cell:hover {
+        transform: translateY(-1px);
+        background: rgba(255, 255, 255, 0.3);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      }
+
+      .plant-token {
+        width: 70px;
+        height: 70px;
+        border-radius: 12px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        color: #0a1f33;
+        font-weight: bold;
+        text-align: center;
+        padding: 8px;
+        box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.4);
+      }
+
+      .plant-token small {
+        font-size: 0.7rem;
+        font-weight: normal;
+      }
+
+      footer {
+        text-align: center;
+        padding: 12px;
+        color: rgba(0, 0, 0, 0.5);
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div id="sun-display">阳光：0</div>
+      <div id="card-bar"></div>
+    </header>
+    <main>
+      <div id="board"></div>
+    </main>
+    <footer>使用占位元素的植物大战僵尸原型</footer>
+    <script type="module" src="./src/main.js"></script>
+  </body>
+</html>

--- a/src/entities/peaShooter.js
+++ b/src/entities/peaShooter.js
@@ -1,0 +1,23 @@
+import Plant from './plant.js';
+
+export default class PeaShooter extends Plant {
+  static get type() {
+    return 'peaShooter';
+  }
+
+  static get displayName() {
+    return '豌豆射手';
+  }
+
+  static get cost() {
+    return 100;
+  }
+
+  static get cooldown() {
+    return 7;
+  }
+
+  static get color() {
+    return '#7ad152';
+  }
+}

--- a/src/entities/plant.js
+++ b/src/entities/plant.js
@@ -1,0 +1,27 @@
+export default class Plant {
+  constructor({ row, col }) {
+    this.row = row;
+    this.col = col;
+    this.type = this.constructor.type;
+  }
+
+  static get type() {
+    return 'plant';
+  }
+
+  static get displayName() {
+    return '植物';
+  }
+
+  static get cost() {
+    return 0;
+  }
+
+  static get cooldown() {
+    return 0;
+  }
+
+  static get color() {
+    return '#cccccc';
+  }
+}

--- a/src/entities/sunflower.js
+++ b/src/entities/sunflower.js
@@ -1,0 +1,23 @@
+import Plant from './plant.js';
+
+export default class Sunflower extends Plant {
+  static get type() {
+    return 'sunflower';
+  }
+
+  static get displayName() {
+    return '向日葵';
+  }
+
+  static get cost() {
+    return 50;
+  }
+
+  static get cooldown() {
+    return 5;
+  }
+
+  static get color() {
+    return '#fdd835';
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,72 @@
+import { setupUI } from './systems/ui.js';
+import Sunflower from './entities/sunflower.js';
+import PeaShooter from './entities/peaShooter.js';
+
+const GRID_ROWS = 5;
+const GRID_COLS = 9;
+
+const plantTypes = [Sunflower, PeaShooter];
+
+const state = {
+  sun: 50,
+  selectedCard: null,
+  board: Array.from({ length: GRID_ROWS }, () => Array(GRID_COLS).fill(null)),
+  cooldowns: plantTypes.reduce((acc, PlantType) => {
+    acc[PlantType.type] = 0;
+    return acc;
+  }, {}),
+};
+
+const ui = setupUI({
+  state,
+  plantTypes,
+  rows: GRID_ROWS,
+  cols: GRID_COLS,
+  onCardSelected: handleCardSelect,
+  onCellClicked: handleCellClick,
+});
+
+function handleCardSelect(type) {
+  const PlantType = plantTypes.find((plant) => plant.type === type);
+  if (!PlantType) return;
+  const now = Date.now();
+  const isCoolingDown = now < state.cooldowns[type];
+  const canAfford = state.sun >= PlantType.cost;
+  if (isCoolingDown || !canAfford) {
+    return;
+  }
+  state.selectedCard = type;
+  ui.render();
+}
+
+function handleCellClick(row, col) {
+  if (!state.selectedCard) return;
+  if (state.board[row][col]) {
+    return;
+  }
+
+  const PlantType = plantTypes.find((plant) => plant.type === state.selectedCard);
+  if (!PlantType) {
+    state.selectedCard = null;
+    return;
+  }
+
+  const now = Date.now();
+  if (state.sun < PlantType.cost || now < state.cooldowns[PlantType.type]) {
+    state.selectedCard = null;
+    ui.render();
+    return;
+  }
+
+  state.board[row][col] = new PlantType({ row, col });
+  state.sun -= PlantType.cost;
+  state.cooldowns[PlantType.type] = now + PlantType.cooldown * 1000;
+  state.selectedCard = null;
+  ui.render();
+}
+
+setInterval(() => {
+  ui.render();
+}, 250);
+
+ui.render();

--- a/src/systems/ui.js
+++ b/src/systems/ui.js
@@ -1,0 +1,137 @@
+const formatSun = (value) => `阳光：${Math.floor(value)}`;
+
+export function setupUI({ state, plantTypes, rows, cols, onCardSelected, onCellClicked }) {
+  const sunDisplay = document.getElementById('sun-display');
+  const cardBar = document.getElementById('card-bar');
+  const boardElement = document.getElementById('board');
+
+  if (!sunDisplay || !cardBar || !boardElement) {
+    throw new Error('UI 容器缺失，无法初始化界面。');
+  }
+
+  const cardElements = new Map();
+
+  plantTypes.forEach((PlantType) => {
+    const card = document.createElement('div');
+    card.className = 'card';
+
+    const title = document.createElement('div');
+    title.className = 'card-title';
+    title.textContent = PlantType.displayName;
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+    body.textContent = `费用：${PlantType.cost}`;
+
+    const footer = document.createElement('div');
+    footer.className = 'card-footer';
+    footer.textContent = `冷却：${PlantType.cooldown}s`;
+
+    card.append(title, body, footer);
+    cardBar.appendChild(card);
+
+    card.addEventListener('click', () => {
+      if (card.classList.contains('disabled')) {
+        return;
+      }
+      onCardSelected(PlantType.type);
+    });
+
+    cardElements.set(PlantType.type, {
+      card,
+      footer,
+      body,
+    });
+  });
+
+  const cellElements = Array.from({ length: rows }, () => Array(cols));
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < cols; col += 1) {
+      const cell = document.createElement('div');
+      cell.className = 'cell';
+      cell.dataset.row = String(row);
+      cell.dataset.col = String(col);
+
+      cell.addEventListener('click', () => {
+        onCellClicked(row, col);
+      });
+
+      boardElement.appendChild(cell);
+      cellElements[row][col] = cell;
+    }
+  }
+
+  function renderSun() {
+    sunDisplay.textContent = formatSun(state.sun);
+  }
+
+  function renderCards() {
+    const now = Date.now();
+    plantTypes.forEach((PlantType) => {
+      const registryEntry = cardElements.get(PlantType.type);
+      if (!registryEntry) return;
+
+      const { card, footer, body } = registryEntry;
+      const remaining = Math.max(0, state.cooldowns[PlantType.type] - now);
+      const isReady = remaining <= 0;
+      const canAfford = state.sun >= PlantType.cost;
+
+      card.classList.toggle('disabled', !isReady || !canAfford);
+      if (state.selectedCard === PlantType.type && (!isReady || !canAfford)) {
+        state.selectedCard = null;
+      }
+      card.classList.toggle(
+        'selected',
+        state.selectedCard === PlantType.type && isReady && canAfford,
+      );
+
+      if (isReady) {
+        footer.textContent = `冷却：${PlantType.cooldown}s`;
+      } else {
+        const seconds = Math.ceil(remaining / 1000);
+        footer.textContent = `冷却中：${seconds}s`;
+      }
+
+      if (canAfford) {
+        body.textContent = `费用：${PlantType.cost}`;
+      } else {
+        body.textContent = `费用：${PlantType.cost}（不足）`;
+      }
+    });
+  }
+
+  function renderBoard() {
+    for (let row = 0; row < rows; row += 1) {
+      for (let col = 0; col < cols; col += 1) {
+        const cell = cellElements[row][col];
+        const plant = state.board[row][col];
+        cell.innerHTML = '';
+        if (plant) {
+          const token = document.createElement('div');
+          token.className = 'plant-token';
+          token.style.background = plant.constructor.color;
+
+          const nameLine = document.createElement('div');
+          nameLine.textContent = plant.constructor.displayName;
+
+          const coordLine = document.createElement('small');
+          coordLine.textContent = `${row + 1}-${col + 1}`;
+
+          token.append(nameLine, coordLine);
+          cell.appendChild(token);
+        }
+      }
+    }
+  }
+
+  function render() {
+    renderSun();
+    renderCards();
+    renderBoard();
+  }
+
+  return {
+    render,
+  };
+}


### PR DESCRIPTION
## Summary
- add a basic HTML layout with a sun counter, card bar, and placeholder board
- implement UI logic to handle card selection, affordability, cooldowns, and grid placement
- define plant entity classes for sunflower and pea shooter with their costs and cooldowns

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68df5bd637fc8331b2f028262837eafa