### PR TITLE
Implement sun economy system

### DIFF
--- a/src/entities/sunflower.js
+++ b/src/entities/sunflower.js
@@ -1,0 +1,36 @@
+import economy from '../systems/economy.js';
+
+const SUN_INTERVAL = 5000; // milliseconds
+const SUN_VALUE = 25;
+
+export default class Sunflower {
+  constructor({ position = { x: 0, y: 0 }, onSunProduced } = {}) {
+    this.position = position;
+    this.onSunProduced = onSunProduced;
+    this.timeAccumulator = 0;
+    this.alive = true;
+  }
+
+  update(deltaTime) {
+    if (!this.alive) {
+      return;
+    }
+
+    this.timeAccumulator += deltaTime;
+
+    if (this.timeAccumulator >= SUN_INTERVAL) {
+      const cycles = Math.floor(this.timeAccumulator / SUN_INTERVAL);
+      const totalSun = cycles * SUN_VALUE;
+      this.timeAccumulator -= cycles * SUN_INTERVAL;
+      economy.addSun(totalSun);
+
+      if (typeof this.onSunProduced === 'function') {
+        this.onSunProduced({ amount: totalSun, producer: this });
+      }
+    }
+  }
+
+  destroy() {
+    this.alive = false;
+  }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,101 @@
+import ui from './ui/ui.js';
+import Sunflower from './entities/sunflower.js';
+import economy, { resetEconomy } from './systems/economy.js';
+
+class Game {
+  constructor() {
+    this.entities = new Set();
+    this.lastTimestamp = null;
+    this.animationFrameId = null;
+    this.running = false;
+  }
+
+  start() {
+    if (this.running) {
+      return;
+    }
+
+    resetEconomy();
+    ui.init();
+
+    this.spawnDefaultPlants();
+
+    this.running = true;
+    this.lastTimestamp = performance.now();
+    this.animationFrameId = requestAnimationFrame(this.tick);
+  }
+
+  stop() {
+    if (!this.running) {
+      return;
+    }
+
+    cancelAnimationFrame(this.animationFrameId);
+    this.animationFrameId = null;
+    this.running = false;
+    this.lastTimestamp = null;
+  }
+
+  spawnDefaultPlants() {
+    if (this.entities.size > 0) {
+      return;
+    }
+
+    const sunflower = new Sunflower();
+    this.entities.add(sunflower);
+  }
+
+  tick = (timestamp) => {
+    if (!this.running) {
+      return;
+    }
+
+    const delta = timestamp - this.lastTimestamp;
+    this.lastTimestamp = timestamp;
+
+    this.entities.forEach((entity) => {
+      if (typeof entity.update === 'function') {
+        entity.update(delta);
+      }
+    });
+
+    this.animationFrameId = requestAnimationFrame(this.tick);
+  };
+
+  addEntity(entity) {
+    if (!entity) {
+      return;
+    }
+
+    this.entities.add(entity);
+  }
+
+  removeEntity(entity) {
+    if (!entity) {
+      return;
+    }
+
+    this.entities.delete(entity);
+
+    if (typeof entity.destroy === 'function') {
+      entity.destroy();
+    }
+  }
+
+  attemptPurchase(cost) {
+    if (economy.spend(cost)) {
+      return true;
+    }
+
+    ui.flashSun(cost);
+    return false;
+  }
+}
+
+const game = new Game();
+
+window.addEventListener('DOMContentLoaded', () => {
+  game.start();
+});
+
+export default game;

--- a/src/systems/economy.js
+++ b/src/systems/economy.js
@@ -1,0 +1,81 @@
+const MINIMUM_SUN = 0;
+const DEFAULT_SUN = 50;
+
+let currentSun = DEFAULT_SUN;
+const listeners = new Set();
+
+function notify() {
+  listeners.forEach((listener) => {
+    try {
+      listener(currentSun);
+    } catch (error) {
+      console.error('Sun economy listener failed', error);
+    }
+  });
+}
+
+function clampSun(value) {
+  return Math.max(MINIMUM_SUN, Math.floor(value));
+}
+
+export function getCurrentSun() {
+  return currentSun;
+}
+
+export function addSun(amount) {
+  if (typeof amount !== 'number' || Number.isNaN(amount)) {
+    return;
+  }
+
+  if (amount <= 0) {
+    return;
+  }
+
+  currentSun = clampSun(currentSun + amount);
+  notify();
+}
+
+export function canAfford(cost) {
+  if (typeof cost !== 'number' || Number.isNaN(cost)) {
+    return false;
+  }
+
+  return currentSun >= cost;
+}
+
+export function spend(cost) {
+  if (!canAfford(cost)) {
+    return false;
+  }
+
+  currentSun = clampSun(currentSun - cost);
+  notify();
+  return true;
+}
+
+export function subscribe(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+
+  listeners.add(listener);
+  listener(currentSun);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function resetEconomy() {
+  currentSun = DEFAULT_SUN;
+  notify();
+}
+
+export default {
+  addSun,
+  canAfford,
+  spend,
+  getCurrentSun,
+  subscribe,
+  resetEconomy,
+};

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -1,0 +1,100 @@
+import economy, { subscribe as subscribeEconomy } from '../systems/economy.js';
+
+class GameUI {
+  constructor() {
+    this.root = null;
+    this.sunText = null;
+    this.unsubscribe = null;
+    this.initialised = false;
+  }
+
+  init() {
+    if (this.initialised) {
+      return;
+    }
+
+    this.root = document.querySelector('[data-ui-root]');
+
+    if (!this.root) {
+      this.root = document.createElement('div');
+      this.root.dataset.uiRoot = 'true';
+      this.root.style.position = 'fixed';
+      this.root.style.top = '16px';
+      this.root.style.left = '16px';
+      this.root.style.padding = '8px 12px';
+      this.root.style.background = 'rgba(255, 255, 255, 0.85)';
+      this.root.style.borderRadius = '6px';
+      this.root.style.boxShadow = '0 2px 8px rgba(0, 0, 0, 0.15)';
+      this.root.style.fontFamily = '"Helvetica Neue", Arial, sans-serif';
+      this.root.style.fontSize = '18px';
+      this.root.style.fontWeight = 'bold';
+      this.root.style.zIndex = '1000';
+      document.body.appendChild(this.root);
+    }
+
+    this.sunText = this.root.querySelector('[data-ui-sun-text]');
+
+    if (!this.sunText) {
+      this.sunText = document.createElement('span');
+      this.sunText.dataset.uiSunText = 'true';
+      this.root.textContent = 'Sun: ';
+      this.root.appendChild(this.sunText);
+    }
+
+    this.unsubscribe = subscribeEconomy((amount) => {
+      if (!this.sunText) {
+        return;
+      }
+
+      this.sunText.textContent = String(amount);
+    });
+
+    this.initialised = true;
+  }
+
+  destroy() {
+    if (typeof this.unsubscribe === 'function') {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+
+    this.initialised = false;
+  }
+
+  flashSun(cost) {
+    if (!this.sunText) {
+      return;
+    }
+
+    this.sunText.animate(
+      [
+        { color: '#f7b733' },
+        { color: '#e32b2b' },
+        { color: '#f7b733' },
+      ],
+      {
+        duration: 600,
+        easing: 'ease-in-out',
+      },
+    );
+
+    if (!economy.canAfford(cost)) {
+      this.root.animate(
+        [
+          { transform: 'translateX(0)' },
+          { transform: 'translateX(-3px)' },
+          { transform: 'translateX(3px)' },
+          { transform: 'translateX(0)' },
+        ],
+        {
+          duration: 300,
+          iterations: 1,
+        },
+      );
+    }
+  }
+}
+
+const ui = new GameUI();
+
+export default ui;


### PR DESCRIPTION
## Summary
- add a global sun economy system with helpers to add and spend sun
- enable sunflowers to produce sun periodically via the economy
- connect the UI and game loop to display and update the current sun total

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68df5bdeaaa4833195d51d70ba91174c