### PR TITLE
Add bullet, zombie, and collision systems

### DIFF
--- a/src/entities/bullet.js
+++ b/src/entities/bullet.js
@@ -1,0 +1,65 @@
+const DEFAULT_BULLET_SPEED = 300; // px per second
+const DEFAULT_BULLET_DAMAGE = 20;
+const DEFAULT_WIDTH = 28;
+const DEFAULT_HEIGHT = 28;
+const DEFAULT_BOARD_WIDTH = 1280;
+
+export default class Bullet {
+  constructor({
+    x,
+    y,
+    row,
+    width = DEFAULT_WIDTH,
+    height = DEFAULT_HEIGHT,
+    speed = DEFAULT_BULLET_SPEED,
+    damage = DEFAULT_BULLET_DAMAGE,
+    boardWidth = DEFAULT_BOARD_WIDTH,
+  }) {
+    this.x = x;
+    this.y = y;
+    this.row = row;
+    this.width = width;
+    this.height = height;
+    this.speed = speed;
+    this.damage = damage;
+    this.boardWidth = boardWidth;
+    this.active = true;
+  }
+
+  update(deltaTime) {
+    if (!this.active) {
+      return;
+    }
+
+    this.x += this.speed * deltaTime;
+
+    if (this.isOutOfBounds()) {
+      this.destroy();
+    }
+  }
+
+  getBounds() {
+    const halfWidth = this.width / 2;
+    const halfHeight = this.height / 2;
+
+    return {
+      left: this.x - halfWidth,
+      right: this.x + halfWidth,
+      top: this.y - halfHeight,
+      bottom: this.y + halfHeight,
+    };
+  }
+
+  isOutOfBounds() {
+    return this.x - this.width / 2 > this.boardWidth;
+  }
+
+  destroy() {
+    this.active = false;
+  }
+}
+
+export {
+  DEFAULT_BULLET_SPEED,
+  DEFAULT_BULLET_DAMAGE,
+};

--- a/src/entities/zombie.js
+++ b/src/entities/zombie.js
@@ -1,0 +1,110 @@
+const DEFAULT_ZOMBIE_HEALTH = 100;
+const DEFAULT_ZOMBIE_SPEED = 20; // px per second
+const DEFAULT_ATTACK_DAMAGE_PER_SECOND = 10;
+const DEFAULT_WIDTH = 80;
+const DEFAULT_HEIGHT = 120;
+
+export default class Zombie {
+  constructor({
+    x,
+    y,
+    row,
+    width = DEFAULT_WIDTH,
+    height = DEFAULT_HEIGHT,
+    speed = DEFAULT_ZOMBIE_SPEED,
+    health = DEFAULT_ZOMBIE_HEALTH,
+  }) {
+    this.x = x;
+    this.y = y;
+    this.row = row;
+    this.width = width;
+    this.height = height;
+    this.speed = speed;
+    this.health = health;
+    this.maxHealth = health;
+    this.active = true;
+    this.isEating = false;
+    this.targetPlant = null;
+  }
+
+  update(deltaTime) {
+    if (!this.active) {
+      return;
+    }
+
+    if (this.isEating && this.targetPlant) {
+      this.applyDamageToPlant(deltaTime);
+      if (!this.targetPlant || this.targetPlant.health <= 0) {
+        this.stopEating();
+      }
+      return;
+    }
+
+    this.x -= this.speed * deltaTime;
+  }
+
+  getBounds() {
+    const halfWidth = this.width / 2;
+    const halfHeight = this.height / 2;
+
+    return {
+      left: this.x - halfWidth,
+      right: this.x + halfWidth,
+      top: this.y - halfHeight,
+      bottom: this.y + halfHeight,
+    };
+  }
+
+  takeDamage(amount) {
+    if (!this.active) {
+      return;
+    }
+
+    this.health -= amount;
+    if (this.health <= 0) {
+      this.die();
+    }
+  }
+
+  die() {
+    this.active = false;
+    this.isEating = false;
+    this.targetPlant = null;
+  }
+
+  startEating(plant) {
+    this.isEating = true;
+    this.targetPlant = plant;
+  }
+
+  stopEating() {
+    this.isEating = false;
+    this.targetPlant = null;
+  }
+
+  applyDamageToPlant(deltaTime) {
+    if (!this.targetPlant) {
+      return;
+    }
+
+    if (typeof this.targetPlant.health !== 'number') {
+      this.targetPlant.health = DEFAULT_PLANT_HEALTH;
+    }
+
+    const damage = DEFAULT_ATTACK_DAMAGE_PER_SECOND * deltaTime;
+    this.targetPlant.health = Math.max(0, this.targetPlant.health - damage);
+
+    if (this.targetPlant.health === 0) {
+      this.targetPlant.destroyed = true;
+    }
+  }
+}
+
+const DEFAULT_PLANT_HEALTH = 100;
+
+export {
+  DEFAULT_ZOMBIE_HEALTH,
+  DEFAULT_ZOMBIE_SPEED,
+  DEFAULT_ATTACK_DAMAGE_PER_SECOND,
+  DEFAULT_PLANT_HEALTH,
+};

--- a/src/systems/collisions.js
+++ b/src/systems/collisions.js
@@ -1,0 +1,125 @@
+import { DEFAULT_PLANT_HEALTH } from '../entities/zombie.js';
+
+const DEFAULT_BOARD_WIDTH = 1280;
+const DEFAULT_PLANT_WIDTH = 80;
+const DEFAULT_PLANT_HEIGHT = 100;
+
+function rectsOverlap(a, b) {
+  return !(
+    a.right < b.left ||
+    a.left > b.right ||
+    a.bottom < b.top ||
+    a.top > b.bottom
+  );
+}
+
+function normalisePlant(plant) {
+  if (typeof plant.width !== 'number') {
+    plant.width = DEFAULT_PLANT_WIDTH;
+  }
+
+  if (typeof plant.height !== 'number') {
+    plant.height = DEFAULT_PLANT_HEIGHT;
+  }
+
+  if (typeof plant.health !== 'number') {
+    plant.health = DEFAULT_PLANT_HEALTH;
+  }
+}
+
+function getEntityBounds(entity) {
+  if (typeof entity.getBounds === 'function') {
+    return entity.getBounds();
+  }
+
+  const halfWidth = entity.width / 2;
+  const halfHeight = entity.height / 2;
+
+  return {
+    left: entity.x - halfWidth,
+    right: entity.x + halfWidth,
+    top: entity.y - halfHeight,
+    bottom: entity.y + halfHeight,
+  };
+}
+
+export function updateCollisions({
+  bullets = [],
+  zombies = [],
+  plants = [],
+  deltaTime = 0,
+  boardWidth = DEFAULT_BOARD_WIDTH,
+}) {
+  bullets.forEach((bullet) => {
+    bullet.boardWidth = boardWidth;
+    bullet.update(deltaTime);
+  });
+
+  zombies.forEach((zombie) => {
+    zombie.update(deltaTime);
+  });
+
+  bullets.forEach((bullet) => {
+    if (!bullet.active) {
+      return;
+    }
+
+    const bulletBounds = bullet.getBounds();
+    zombies.forEach((zombie) => {
+      if (!zombie.active || zombie.row !== bullet.row || !bullet.active) {
+        return;
+      }
+
+      const zombieBounds = zombie.getBounds();
+      if (rectsOverlap(bulletBounds, zombieBounds)) {
+        zombie.takeDamage(bullet.damage);
+        bullet.destroy();
+      }
+    });
+  });
+
+  zombies.forEach((zombie) => {
+    if (!zombie.active) {
+      return;
+    }
+
+    if (zombie.isEating && zombie.targetPlant) {
+      if (zombie.targetPlant.destroyed) {
+        zombie.stopEating();
+      } else {
+        const plantBounds = getEntityBounds(zombie.targetPlant);
+        const zombieBounds = zombie.getBounds();
+        if (!rectsOverlap(zombieBounds, plantBounds)) {
+          zombie.stopEating();
+        }
+      }
+    }
+
+    if (!zombie.isEating) {
+      plants
+        .filter((plant) => plant.row === zombie.row && !plant.destroyed)
+        .some((plant) => {
+          normalisePlant(plant);
+          const plantBounds = getEntityBounds(plant);
+          const zombieBounds = zombie.getBounds();
+          if (rectsOverlap(zombieBounds, plantBounds)) {
+            zombie.startEating(plant);
+            return true;
+          }
+          return false;
+        });
+    }
+
+    if (zombie.isEating) {
+      zombie.applyDamageToPlant(deltaTime);
+    }
+  });
+
+  return {
+    bullets: bullets.filter((bullet) => bullet.active),
+    zombies: zombies.filter((zombie) => zombie.active),
+    plants: plants.filter((plant) => !plant.destroyed),
+  };
+}
+
+export default updateCollisions;


### PR DESCRIPTION
## Summary
- add a Bullet entity with movement, damage, and out-of-bounds cleanup
- implement a Zombie entity that advances, attacks plants, and tracks health
- create a collision system to resolve bullet-zombie hits and zombie-plant encounters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68df5be426b4833193946f074c178ece